### PR TITLE
Update font urls in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,11 @@ Suggested Usage:
 ```css
 @font-face{ 
     font-family: 'FGDCGeoAge';
-    src: url('http://ncgmp09.github.io/fgdc-geoage-font/fgdcgeoage.eot');
-    src: url('http://ncgmp09.github.io/fgdc-geoage-font/fgdcgeoage.eot?#iefix') format('embedded-opentype'),
-         url('http://ncgmp09.github.io/fgdc-geoage-font/fgdcgeoage.woff') format('woff'),
-         url('http://ncgmp09.github.io/fgdc-geoage-font/fgdcgeoage.ttf') format('truetype'),
-         url('http://ncgmp09.github.io/fgdc-geoage-font/fgdcgeoage.svg#FGDCGeoAge') format('svg');
+    src: url('//azgs-geomapmaker.github.io/fgdc-geoage-font/fgdcgeoage.eot');
+    src: url('//azgs-geomapmaker.github.io/fgdc-geoage-font/fgdcgeoage.eot?#iefix') format('embedded-opentype'),
+         url('//azgs-geomapmaker.github.io/fgdc-geoage-font/fgdcgeoage.woff') format('woff'),
+         url('//azgs-geomapmaker.github.io/fgdc-geoage-font/fgdcgeoage.ttf') format('truetype'),
+         url('//azgs-geomapmaker.github.io/fgdc-geoage-font/fgdcgeoage.svg#FGDCGeoAge') format('svg');
 }
 ```
 


### PR DESCRIPTION
:wave: Hi! 

I noticed that you moved this GitHub repository to a new org. That means the URLs to access the fonts hosted by GitHub Pages have to change. Here is just a small proposal to adjust the readme to reflect that!